### PR TITLE
last-modified header

### DIFF
--- a/lib/Catalyst/View/JavaScript/Minifier/XS.pm
+++ b/lib/Catalyst/View/JavaScript/Minifier/XS.pm
@@ -7,7 +7,9 @@ use Moose;
 
 extends 'Catalyst::View';
 
+use File::stat;
 use JavaScript::Minifier::XS qw/minify/;
+use List::Util 'max';
 use Moose::Util::TypeConstraints;
 use MooseX::Aliases;
 use Path::Class::Dir;
@@ -69,6 +71,7 @@ sub process {
 
    my $output = $self->_combine_files($c, \@files);
 
+   $c->res->headers->last_modified( max map stat($_)->mtime, @files );
    $c->res->body( $self->_minify($c, $output) );
 }
 

--- a/t/01-basic.t
+++ b/t/01-basic.t
@@ -4,6 +4,7 @@ use strict;
 use warnings;
 
 use FindBin;
+use File::stat;
 use Test::More;
 use File::Spec;
 use JavaScript::Minifier::XS 'minify';
@@ -11,7 +12,8 @@ use JavaScript::Minifier::XS 'minify';
 use lib "$FindBin::Bin/../lib", "$FindBin::Bin/lib";
 use Catalyst::Test 'TestApp';
 
-my $served = get('/test');
+my $res = request('/test');
+my $served = $res->content;
 
 ok $served, q{served data isn't blank};
 my $path = File::Spec->catfile($FindBin::Bin, qw{lib TestApp root js foo.js});
@@ -23,6 +25,9 @@ while (<$file>) {
 }
 
 is minify($str), $served, 'server actually minifed the javascript';
+is $res->headers->last_modified, stat($path)->mtime, 'right modtime header';
+
+
 
 done_testing;
 


### PR DESCRIPTION
Got some changes to set the Last-Modified header on the JS packs that are served.

This, along with a bit of controller logic, will allow client-side caching of the packs with If-Modified-Since requests.

See http://github.com/solgenomics/sgn/commit/11fc571b84af408c504c7b266d0bb6cc221eeb40 for the controller side of it.
